### PR TITLE
Register Vault plugins after Vault helm chart installation.

### DIFF
--- a/third_party/vault/plugin-secrets-kubernetes-reader/values.yaml
+++ b/third_party/vault/plugin-secrets-kubernetes-reader/values.yaml
@@ -24,11 +24,13 @@ server:
   # This can be used to automate processes such as initialization
   # or boostrapping auth methods.
   postStart:
-    - /bin/sh
-    - -ec
+    - "sh"
+    - "-c"
     # Sleep command is needed to avoid synchronization issues with the container pod. Please see
     # https://kubernetes.io/docs/tasks/configure-pod-container/attach-handler-lifecycle-event/#discussion
     # FIXME: Use a proper way to configure Vault after Vault start-up
-    - >
-      sleep 5 &&
+    - |
+      sleep 5
+      SHA256=$(sha256sum /usr/local/libexec/vault/vault-plugin-secrets-kubernetes-reader | cut -d ' ' -f1) &&
+      vault plugin register -sha256=$SHA256 secret vault-plugin-secrets-kubernetes-reader
       vault secrets enable -path=kubernetes-secrets vault-plugin-secrets-kubernetes-reader

--- a/third_party/vault/vault-single-cluster/values.yaml
+++ b/third_party/vault/vault-single-cluster/values.yaml
@@ -34,7 +34,9 @@ server:
       # configuring kubernetes auth method and use it later to create roles.
       vault auth enable kubernetes
       vault write auth/kubernetes/config kubernetes_host="https://kubernetes.default.svc:443"
-      # enable secret engine
+      # register and enable secret engine
+      SHA256=$(sha256sum /usr/local/libexec/vault/vault-plugin-secrets-kubernetes-reader | cut -d ' ' -f1)
+      vault plugin register -sha256=$SHA256 secret vault-plugin-secrets-kubernetes-reader
       vault secrets enable -path=kubernetes-secrets vault-plugin-secrets-kubernetes-reader
       # create policy to access secrets
       # NOTE: m4d/dataset-creds/ secret engine is enabled by the manager and is used temporarily


### PR DESCRIPTION
The Vault plugin registration phase is done automatically in Vault "dev" mode. (https://www.vaultproject.io/docs/commands/server#dev-options)
This PR adds plugin registration so that the Vault plugin deployment could work also in non "dev" mode.