### PR TITLE
Support different APIVersions of cert-manager.

### DIFF
--- a/charts/m4d/files/webhook-configs.yaml
+++ b/charts/m4d/files/webhook-configs.yaml
@@ -5,6 +5,7 @@ metadata:
   name: '{{ .Release.Namespace }}-mutating-webhook'
   annotations:
     cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/serving-cert'
+    certmanager.k8s.io/inject-ca-from: '{{ .Release.Namespace }}/serving-cert'
 webhooks:
   - clientConfig:
       caBundle: Cg==

--- a/charts/m4d/templates/_helpers.tpl
+++ b/charts/m4d/templates/_helpers.tpl
@@ -93,9 +93,7 @@ Detect the version of cert manager crd that is installed
 Error if CRD is not available
 */}}
 {{- define "m4d.certManagerApiVersion" -}}
-{{- if (.Capabilities.APIVersions.Has "cert-manager.io/v1alpha3") -}}
-cert-manager.io/v1alpha3
-{{- else if (.Capabilities.APIVersions.Has "cert-manager.io/v1alpha2") -}}
+{{- if (.Capabilities.APIVersions.Has "cert-manager.io/v1alpha2") -}}
 cert-manager.io/v1alpha2
 {{- else if (.Capabilities.APIVersions.Has "certmanager.k8s.io/v1alpha1") -}}
 certmanager.k8s.io/v1alpha1

--- a/charts/m4d/templates/_helpers.tpl
+++ b/charts/m4d/templates/_helpers.tpl
@@ -87,3 +87,19 @@ isRazeeEnabled checks if razee configuration is enabled
 true
 {{- end -}}
 {{- end }}
+
+{{/*
+Detect the version of cert manager crd that is installed
+Error if CRD is not available
+*/}}
+{{- define "m4d.certManagerApiVersion" -}}
+{{- if (.Capabilities.APIVersions.Has "cert-manager.io/v1alpha3") -}}
+cert-manager.io/v1alpha3
+{{- else if (.Capabilities.APIVersions.Has "cert-manager.io/v1alpha2") -}}
+cert-manager.io/v1alpha2
+{{- else if (.Capabilities.APIVersions.Has "certmanager.k8s.io/v1alpha1") -}}
+certmanager.k8s.io/v1alpha1
+{{- else  -}}
+{{- fail "cert-manager CRD does not appear to be installed" }}
+{{- end -}}
+{{- end -}}

--- a/charts/m4d/templates/webhook-certificates.yaml
+++ b/charts/m4d/templates/webhook-certificates.yaml
@@ -1,5 +1,5 @@
 {{- if include "m4d.isEnabled" (tuple .Values.manager.enabled (or .Values.coordinator.enabled .Values.worker.enabled)) }}
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: {{ include "m4d.certManagerApiVersion" . }}
 kind: Issuer
 metadata:
   name: selfsigned-issuer
@@ -8,7 +8,7 @@ spec:
   selfSigned: {}
 
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: {{ include "m4d.certManagerApiVersion" . }}
 kind: Certificate
 metadata:
   name: serving-cert


### PR DESCRIPTION
Addresses issue #581.

Tested with quick-start using cert-manager v0.10.1 and cert-manager v1.2.0