### PR TITLE
Fix quickstart documentation

### DIFF
--- a/site/docs/get-started/quickstart.md
+++ b/site/docs/get-started/quickstart.md
@@ -70,7 +70,7 @@ Run the following to install vault and the plugin in development mode:
     git clone https://github.com/mesh-for-data/mesh-for-data.git
     cd mesh-for-data
     helm install m4d-crd charts/m4d-crd -n m4d-system --wait
-    helm install m4d charts/m4d -n m4d-system --wait
+    helm install m4d charts/m4d --set global.tag=latest -n m4d-system --wait
     ```
 
 The control plane includes a `manager` service that connects to a data catalog and to a policy manager. 


### PR DESCRIPTION
There is currently inconsistency between the crd and the images that are deployed using the instructions in "Install latest development version from GitHub" section from the quick-start page(https://mesh-for-data.github.io/mesh-for-data/v0.1/get-started/quickstart/); the crd are from latest version while the images are with tag 0.1.0
This PR changes the images to be with tag latest.
Fixes issue #578 