### PR TITLE
Plotter generation problems during a unit test

### DIFF
--- a/manager/controllers/app/m4dapplication_controller_test.go
+++ b/manager/controllers/app/m4dapplication_controller_test.go
@@ -63,6 +63,10 @@ var _ = Describe("M4DApplication Controller", func() {
 			// The plotter has to be created
 			plotter := &apiv1alpha1.Plotter{}
 			plotterObjectKey := client.ObjectKey{Namespace: application.Status.Generated.Namespace, Name: application.Status.Generated.Name}
+			Eventually(func() error {
+				return k8sClient.Get(context.Background(), plotterObjectKey, plotter)
+			}, timeout, interval).Should(Succeed())
+
 			By("Expect plotter to be ready at some point")
 			Eventually(func() bool {
 				Expect(k8sClient.Get(context.Background(), plotterObjectKey, plotter)).To(Succeed())


### PR DESCRIPTION
Signed-off-by: Shlomit Koyfman <shlomitk@il.ibm.com>
One of the errors in CI unit tests is that an application could not produce a plotter. The reason is some weird timing issue when a plotter generation request is sent but the resource itself is not created, while a test assumes that the resource exists.
This PR adds an additional wait for the plotter resource.