### PR TITLE
charts: remove hardcoded m4d-system in default vault address 

### DIFF
--- a/charts/m4d/templates/m4d-config.yaml
+++ b/charts/m4d/templates/m4d-config.yaml
@@ -11,7 +11,7 @@ data:
   MAIN_POLICY_MANAGER_NAME: {{ .Values.coordinator.policyManager | quote }}
   MAIN_POLICY_MANAGER_CONNECTOR_URL: {{ .Values.coordinator.policyManagerConnectorURL | default (printf "%s-connector:80" .Values.coordinator.policyManager) | quote }}
   USE_EXTENSIONPOLICY_MANAGER: "false" # deprecated
-  VAULT_ADDRESS: {{ .Values.coordinator.vault.address | quote }}
+  VAULT_ADDRESS: {{ tpl .Values.coordinator.vault.address . | quote }}
   VAULT_MODULES_ROLE: "module" # temporary
   {{- end }}
 {{- end }}

--- a/charts/m4d/values.yaml
+++ b/charts/m4d/values.yaml
@@ -65,7 +65,7 @@ coordinator:
   # Configure the vault instance to be used by the coordinator manager
   vault:
     # Set to the Vault address. 
-    address: "http://vault.m4d-system:8200"
+    address: "http://vault.{{ .Release.Namespace }}:8200"
     # Login method to Vault
     login:
       # Token authentication


### PR DESCRIPTION
Fix issue #521:
Currently this value is hardcoded in https://github.com/IBM/the-mesh-for-data/blob/9cf125f1ca0551a54a85e89cca87b547dd896fc2/charts/m4d/values.yaml#L79

In this PR we use {{ .Release.Namespace }} and pass the value to tpl function