### PR TITLE
Add a command to wait for Vault pods to be ready

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ run-integration-tests: export VALUES_FILE=m4d/integration-tests.values.yaml
 run-integration-tests:
 	$(MAKE) kind
 	$(MAKE) -C charts vault
+	$(MAKE) -C charts wait-for-vault
 	$(MAKE) -C charts cert-manager
 	$(MAKE) -C third_party/datashim deploy
 	$(MAKE) docker
@@ -59,6 +60,7 @@ run-deploy-tests:
 cluster-prepare:
 	$(MAKE) -C charts cert-manager
 	$(MAKE) -C charts vault
+	$(MAKE) -C charts wait-for-vault
 	$(MAKE) -C third_party/datashim deploy
 
 .PHONY: cluster-prepare-wait

--- a/charts/Makefile
+++ b/charts/Makefile
@@ -39,6 +39,10 @@ vault:
 	kubectl apply -f ../third_party/vault/plugin-secrets-kubernetes-reader/clusterrole.yaml -n m4d-system || true
 	kubectl apply -f ../third_party/vault/plugin-secrets-kubernetes-reader/clusterrolebinding.yaml -n m4d-system || true
 
+.PHONY: wait-for-vault
+wait-for-vault:
+	kubectl wait --for=condition=ready --all pod -n m4d-system --timeout=120s
+
 .PHONY:
 vault-setup:
 	$(MAKE) configure-vault

--- a/site/docs/get-started/quickstart.md
+++ b/site/docs/get-started/quickstart.md
@@ -44,6 +44,7 @@ Run the following to install vault and the plugin in development mode:
         --set "injector.enabled=false" \
         --values https://raw.githubusercontent.com/mesh-for-data/mesh-for-data/v0.1.0/third_party/vault/vault-single-cluster/values.yaml \
         --wait --timeout 120s
+    kubectl wait --for=condition=ready --all pod -n m4d-system --timeout=120s
     kubectl apply -f https://raw.githubusercontent.com/mesh-for-data/mesh-for-data/v0.1.0/third_party/vault/vault-single-cluster/vault-rbac.yaml -n m4d-system
     ```
 
@@ -58,6 +59,7 @@ Run the following to install vault and the plugin in development mode:
         --set "server.dev.enabled=true" \
         --values https://raw.githubusercontent.com/mesh-for-data/mesh-for-data/v0.1.0/third_party/vault/vault-single-cluster/values.yaml \
         --wait --timeout 120s
+    kubectl wait --for=condition=ready --all pod -n m4d-system --timeout=120s
     kubectl apply -f https://raw.githubusercontent.com/mesh-for-data/mesh-for-data/v0.1.0/third_party/vault/vault-single-cluster/vault-rbac.yaml -n m4d-system
     ```
 


### PR DESCRIPTION
Deploying Vault with  --set "injector.enabled=false" causes it to not apply a deployment resource which seems to affect the helm --wait command: "helm install --wait..." exits immediately and does not wait till the vault pod is ready as expected. Thus a wait command needed to be added independently before continuing the deployment of other components in the control plane.
This PR adds such wait command,