### PR TITLE
Add README.md to third_party/datashim dir. 

### DIFF
--- a/third_party/datashim/README.md
+++ b/third_party/datashim/README.md
@@ -1,0 +1,4 @@
+### Datashim deployment
+
+This folder contains instructions to deploy datashim on Kubernetes/Minikube as described in [datashim site Quickstart section](https://github.com/datashim-io/datashim#quickstart).
+For more deployment options based on your environment please refer to the [datashim site](https://github.com/datashim-io/datashim).


### PR DESCRIPTION
Datashim deployment on Openshift is different if it is running on IBM cloud or not so `WITH_OPENSHIFT` statement is not enough for choosing the openshift installation. To avoid confusion a README.md file was added with a pointer to the datashim site for additional deployment details based on the running environment.

Closes #573 