### PR TITLE
upgrading k8s version to 1.19.1

### DIFF
--- a/hack/tools/create_kind.sh
+++ b/hack/tools/create_kind.sh
@@ -8,7 +8,7 @@ op=$1
 
 source ./common.sh
 
-K8S_VERSION=${K8S_VERSION:-v1.16.15}
+K8S_VERSION=${K8S_VERSION:-v1.19.1}
 : ${KUBE_NAMESPACE:=m4d-system}
 : ${KEEP_PROXY:=true}
 

--- a/hack/tools/docker_mirror.conf
+++ b/hack/tools/docker_mirror.conf
@@ -2,7 +2,7 @@ alpine:latest
 alpine/socat:latest
 banzaicloud/bank-vaults:master
 kindest/kindnetd:0.5.4
-kindest/node:v1.16.9
+kindest/node:v1.19.1
 library/vault:1.3.1
 openjdk:8u131-jre-alpine
 openpolicyagent/kube-mgmt:0.11


### PR DESCRIPTION
Signed-off-by: Shlomit Koyfman <shlomitk@il.ibm.com>

According to https://github.com/kubernetes-sigs/kubespray/issues/6662 k8s version 1.18+ is required to support the latest datashim manifest.