### PR TITLE
Changing the generated bucket/dataset name

### DIFF
--- a/manager/controllers/app/storage.go
+++ b/manager/controllers/app/storage.go
@@ -6,6 +6,7 @@ package app
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/go-logr/logr"
 	app "github.com/mesh-for-data/mesh-for-data/manager/apis/app/v1alpha1"
@@ -53,5 +54,6 @@ func AllocateBucket(c client.Client, log logr.Logger, owner types.NamespacedName
 
 func generateDatasetName(owner types.NamespacedName, id string) string {
 	name := owner.Name + "-" + owner.Namespace + utils.Hash(id, 10)
+	name = strings.ReplaceAll(name, ".", "-")
 	return utils.K8sConformName(name)
 }


### PR DESCRIPTION
Signed-off-by: Shlomit Koyfman <shlomitk@il.ibm.com>

Fixes https://github.com/mesh-for-data/mesh-for-data/issues/649

This PR generates a bucket/dataset name without dots because this name is propagated to PVC resource which complains about such names.