### PR TITLE
Add issuer to vault configuraton for kubernetes version 1.21

### DIFF
--- a/charts/vault/env/dev/vault-single-cluster-values.yaml
+++ b/charts/vault/env/dev/vault-single-cluster-values.yaml
@@ -4,19 +4,40 @@ vault:
     volumes:
       - name: plugins
         emptyDir: {}
+      - name: poststartvolume
+        emptyDir: {}
+      - name: configvolume # this volume is read only
+        configMap:
+          name: vault-poststart-cm
+          defaultMode: 0744
     volumeMounts:
       - mountPath: /usr/local/libexec/vault
         name: plugins
+        readOnly: false
+      - mountPath: /opt/config
+        name: poststartvolume
+        readOnly: false
+      - mountPath: /etc/config/poststart.sh
+        subPath: poststart.sh
+        name: configvolume
         readOnly: false
     extraInitContainers:
       - name: kubesecrets-plugin
         image: ghcr.io/mesh-for-data/vault-plugin-secrets-kubernetes-reader:latest
         command: [/bin/sh, -ec]
         args:
-          - cp /vault-plugin-secrets-kubernetes-reader /usr/local/libexec/vault/vault-plugin-secrets-kubernetes-reader
+          - |
+            cp /vault-plugin-secrets-kubernetes-reader /usr/local/libexec/vault/vault-plugin-secrets-kubernetes-reader
+            cp /etc/config/poststart.sh /opt/config/poststart.sh
         volumeMounts:
         - name: plugins
           mountPath: /usr/local/libexec/vault
+          readOnly: false
+        - name: poststartvolume
+          mountPath: /opt/config
+          readOnly: false
+        - name: configvolume
+          mountPath: /etc/config
           readOnly: false
     extraEnvironmentVars:
       VAULT_API_ADDR: http://127.0.0.1:8200
@@ -27,28 +48,7 @@ vault:
     postStart:
       - "sh"
       - "-c"
-      # Sleep command is needed to avoid synchronization issues with the container pod. Please see
-      # https://kubernetes.io/docs/tasks/configure-pod-container/attach-handler-lifecycle-event/#discussion
-      # FIXME: Use a proper way to configure Vault after Vault start-up
       - |
         sleep 5
-        # configuring kubernetes auth method and use it later to create roles.
-        vault auth enable kubernetes
-        vault write auth/kubernetes/config kubernetes_host="https://kubernetes.default.svc:443"
-        # register and enable secret engine
-        SHA256=$(sha256sum /usr/local/libexec/vault/vault-plugin-secrets-kubernetes-reader | cut -d ' ' -f1)
-        vault plugin register -sha256=$SHA256 secret vault-plugin-secrets-kubernetes-reader
-        vault secrets enable -path=kubernetes-secrets vault-plugin-secrets-kubernetes-reader
-        # create policy to access secrets
-        # NOTE: m4d/dataset-creds/ secret engine is enabled by the manager and is used temporarily
-        # to store dataset credentials.
-        vault policy write "allow-all-dataset-creds" - <<EOF
-        path "kubernetes-secrets/*" {
-        capabilities = ["create", "read", "update", "delete", "list"]
-        }
-        EOF
-        # allow modules running in m4d-blueprints namespace to access dataset credentials
-        vault write auth/kubernetes/role/module bound_service_account_names="*" bound_service_account_namespaces="m4d-blueprints" policies="allow-all-dataset-creds" ttl=24h
-        # enable userpass auth method
-        vault auth enable userpass
-        vault write auth/userpass/users/data_provider password=password policies="allow-all-dataset-creds"
+        /opt/config/poststart.sh
+

--- a/charts/vault/env/dev/vault-single-cluster-values.yaml
+++ b/charts/vault/env/dev/vault-single-cluster-values.yaml
@@ -49,6 +49,9 @@ vault:
       - "sh"
       - "-c"
       - |
+        # Sleep command is needed to avoid synchronization issues with the container pod. Please see
+        # https://kubernetes.io/docs/tasks/configure-pod-container/attach-handler-lifecycle-event/#discussion
+        # FIXME: Use a proper way to configure Vault after Vault start-up
         sleep 5
         /opt/config/poststart.sh
 

--- a/charts/vault/env/dev/vault-single-cluster-values.yaml
+++ b/charts/vault/env/dev/vault-single-cluster-values.yaml
@@ -20,7 +20,6 @@ vault:
       - mountPath: /etc/config/poststart.sh
         subPath: poststart.sh
         name: configvolume
-        readOnly: false
     extraInitContainers:
       - name: kubesecrets-plugin
         image: ghcr.io/mesh-for-data/vault-plugin-secrets-kubernetes-reader:latest

--- a/charts/vault/templates/post-pod-creation-cm.yaml
+++ b/charts/vault/templates/post-pod-creation-cm.yaml
@@ -1,5 +1,3 @@
-{{- $major := .Capabilities.KubeVersion.Major -}}
-{{- $minor := .Capabilities.KubeVersion.Minor -}}
 kind: ConfigMap
 apiVersion: v1
 metadata:
@@ -9,7 +7,7 @@ data:
   poststart.sh: | 
       # configuring kubernetes auth method and use it later to create roles.
       vault auth enable kubernetes
-{{- if and (lt (int $major) 2) (lt (int $minor) 21) }}
+{{- if semverCompare "<1.21-0" .Capabilities.KubeVersion.GitVersion }}
       vault write auth/kubernetes/config kubernetes_host="https://kubernetes.default.svc:443"
 {{- else }}
       vault write auth/kubernetes/config issuer="https://kubernetes.default.svc.cluster.local" kubernetes_host="https://kubernetes.default.svc:443"

--- a/charts/vault/templates/post-pod-creation-cm.yaml
+++ b/charts/vault/templates/post-pod-creation-cm.yaml
@@ -1,0 +1,34 @@
+{{- $major := .Capabilities.KubeVersion.Major -}}
+{{- $minor := .Capabilities.KubeVersion.Minor -}}
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  namespace: {{ .Release.Namespace }} 
+  name: vault-poststart-cm
+data:
+  poststart.sh: | 
+      # configuring kubernetes auth method and use it later to create roles.
+      vault auth enable kubernetes
+{{- if and (lt (int $major) 2) (lt (int $minor) 21) }}
+      vault write auth/kubernetes/config kubernetes_host="https://kubernetes.default.svc:443"
+{{- else }}
+      vault write auth/kubernetes/config issuer="https://kubernetes.default.svc.cluster.local" kubernetes_host="https://kubernetes.default.svc:443"
+{{- end }}
+      # register and enable secret engine
+      SHA256=$(sha256sum /usr/local/libexec/vault/vault-plugin-secrets-kubernetes-reader | cut -d ' ' -f1)
+      vault plugin register -sha256=$SHA256 secret vault-plugin-secrets-kubernetes-reader
+      vault secrets enable -path=kubernetes-secrets vault-plugin-secrets-kubernetes-reader
+      # create policy to access secrets
+      # NOTE: m4d/dataset-creds/ secret engine is enabled by the manager and is used temporarily
+      # to store dataset credentials.
+      vault policy write "allow-all-dataset-creds" - <<EOF
+      path "kubernetes-secrets/*" {
+      capabilities = ["create", "read", "update", "delete", "list"]
+      }
+      EOF
+      # allow modules running in m4d-blueprints namespace to access dataset credentials
+      vault write auth/kubernetes/role/module bound_service_account_names="*" bound_service_account_namespaces="m4d-blueprints" policies="allow-all-dataset-creds" ttl=24h
+      # enable userpass auth method
+      vault auth enable userpass
+      vault write auth/userpass/users/data_provider password=password policies="allow-all-dataset-creds"
+

--- a/charts/vault/templates/post-pod-creation-cm.yaml
+++ b/charts/vault/templates/post-pod-creation-cm.yaml
@@ -7,7 +7,7 @@ data:
   poststart.sh: | 
       # configuring kubernetes auth method and use it later to create roles.
       vault auth enable kubernetes
-{{- if semverCompare "<1.21-0" .Capabilities.KubeVersion.GitVersion }}
+{{- if semverCompare "<1.21-0" .Capabilities.KubeVersion.Version }}
       vault write auth/kubernetes/config kubernetes_host="https://kubernetes.default.svc:443"
 {{- else }}
       vault write auth/kubernetes/config issuer="https://kubernetes.default.svc.cluster.local" kubernetes_host="https://kubernetes.default.svc:443"

--- a/hack/tools/vault_utils.sh
+++ b/hack/tools/vault_utils.sh
@@ -4,7 +4,6 @@
 
 : ${PORT_TO_FORWARD:=8200}
 
-
 # Enable userpass auth method
 # $1 user name
 # $2 password
@@ -50,6 +49,7 @@ enable_k8s_auth() {
         kubectl get secret $2 -n $3 -o jsonpath="{.data['ca\.crt']}" | base64 --decode > tmp/ca.crt
 
         # Configure the k8s sa auth
+        # TODO: Add issuer for kubernetes versions greater than 1.20
         echo "configuring k8s auth"
         bin/vault write auth/"$1"/config \
         token_reviewer_jwt="$TOKEN_REVIEW_JWT" \


### PR DESCRIPTION
For the latest kubernetes version (1.21) issuer should be added when configuring Vault Kubernetes auth method:
https://www.hashicorp.com/blog/retrieve-hashicorp-vault-secrets-with-kubernetes-csi
https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#service-account-issuer-discovery

This PR adds the issuer based on the Kubernetes version.

Tested with kind v0.10.0 default k8s version v1.20.2 and kind V0.11.1 default k8s version  v1.21.1
Closes #672 

