### PR TITLE
No need for reconcile if m4dapplication is in Deny state

### DIFF
--- a/manager/apis/app/v1alpha1/m4dapplication_types.go
+++ b/manager/apis/app/v1alpha1/m4dapplication_types.go
@@ -102,8 +102,9 @@ const (
 
 // Condition indices are static. Conditions always present in the status.
 const (
-	FailureConditionIndex int64 = 0
-	ErrorConditionIndex   int64 = 1
+	ReadyConditionIndex int64 = 0
+	DenyConditionIndex  int64 = 1
+	ErrorConditionIndex int64 = 2
 )
 
 // ConditionType represents a condition type
@@ -113,8 +114,11 @@ const (
 	// ErrorCondition means that an error was encountered during blueprint construction
 	ErrorCondition ConditionType = "Error"
 
-	// FailureCondition means that a blueprint could not be constructed
-	FailureCondition ConditionType = "Failure"
+	// DenyCondition means that access to a dataset is denied
+	DenyCondition ConditionType = "Deny"
+
+	// ReadyCondition means that access to a dataset is granted
+	ReadyCondition ConditionType = "Ready"
 )
 
 // Condition describes the state of a M4DApplication at a certain point.

--- a/manager/apis/app/v1alpha1/m4dapplication_types.go
+++ b/manager/apis/app/v1alpha1/m4dapplication_types.go
@@ -92,6 +92,7 @@ type M4DApplicationSpec struct {
 
 // ErrorMessages that are reported to the user
 const (
+	InvalidAssetID              string = "The asset does not exist."
 	ReadAccessDenied            string = "Governance policies forbid access to the data."
 	CopyNotAllowed              string = "Copy of the data is required but can not be done according to the governance policies."
 	WriteNotAllowed             string = "Governance policies forbid writing of the data."

--- a/manager/controllers/app/m4dapplication_conditions.go
+++ b/manager/controllers/app/m4dapplication_conditions.go
@@ -70,7 +70,7 @@ func getErrorMessages(application *app.M4DApplication) string {
 		errorMsgs = append(errorMsgs, application.Status.Conditions[app.ErrorConditionIndex].Message)
 	}
 	if application.Status.Conditions[app.DenyConditionIndex].Status == corev1.ConditionTrue {
-		errorMsgs[1] = application.Status.Conditions[app.DenyConditionIndex].Message
+		errorMsgs = append(errorMsgs, application.Status.Conditions[app.DenyConditionIndex].Message)
 	}
 	return strings.Join(errorMsgs, "\n")
 }

--- a/manager/controllers/app/m4dapplication_conditions.go
+++ b/manager/controllers/app/m4dapplication_conditions.go
@@ -11,31 +11,41 @@ import (
 // Helper functions to manage conditions
 
 func resetConditions(application *app.M4DApplication) {
-	application.Status.Conditions = make([]app.Condition, 2)
+	application.Status.Ready = false
+	application.Status.Conditions = make([]app.Condition, 3)
 	application.Status.Conditions[app.ErrorConditionIndex] = app.Condition{Type: app.ErrorCondition, Status: corev1.ConditionFalse}
-	application.Status.Conditions[app.FailureConditionIndex] = app.Condition{Type: app.FailureCondition, Status: corev1.ConditionFalse}
+	application.Status.Conditions[app.DenyConditionIndex] = app.Condition{Type: app.DenyCondition, Status: corev1.ConditionFalse}
+	application.Status.Conditions[app.ReadyConditionIndex] = app.Condition{Type: app.ReadyCondition, Status: corev1.ConditionFalse}
 }
 
-func setCondition(application *app.M4DApplication, assetID string, msg string, fatalError bool) {
+func setErrorCondition(application *app.M4DApplication, assetID string, msg string) {
 	if len(application.Status.Conditions) == 0 {
 		resetConditions(application)
 	}
 	errMsg := "An error was received"
 	if assetID != "" {
-		errMsg += " for asset " + assetID + " . "
+		errMsg += " for asset " + assetID
 	}
-	if !fatalError {
-		errMsg += "If the error persists, please contact an operator.\n"
-	}
+	errMsg += " . If the error persists, please contact an operator.\n"
 	errMsg += "Error description: " + msg + "\n"
-	var ind int64
-	if fatalError {
-		ind = app.FailureConditionIndex
-	} else {
-		ind = app.ErrorConditionIndex
+	application.Status.Conditions[app.ErrorConditionIndex].Status = corev1.ConditionTrue
+	application.Status.Conditions[app.ErrorConditionIndex].Message += errMsg
+}
+
+func setDenyCondition(application *app.M4DApplication, assetID string, msg string) {
+	if len(application.Status.Conditions) == 0 {
+		resetConditions(application)
 	}
-	application.Status.Conditions[ind].Status = corev1.ConditionTrue
-	application.Status.Conditions[ind].Message += errMsg
+	application.Status.Conditions[app.DenyConditionIndex].Status = corev1.ConditionTrue
+	application.Status.Conditions[app.DenyConditionIndex].Message = msg
+}
+
+func setReadyCondition(application *app.M4DApplication, assetID string) {
+	if len(application.Status.Conditions) == 0 {
+		resetConditions(application)
+	}
+	application.Status.Conditions[app.ReadyConditionIndex].Status = corev1.ConditionTrue
+	application.Status.Ready = true
 }
 
 func hasError(application *app.M4DApplication) bool {
@@ -44,7 +54,17 @@ func hasError(application *app.M4DApplication) bool {
 		return false
 	}
 	return (application.Status.Conditions[app.ErrorConditionIndex].Status == corev1.ConditionTrue ||
-		application.Status.Conditions[app.FailureConditionIndex].Status == corev1.ConditionTrue)
+		application.Status.Conditions[app.DenyConditionIndex].Status == corev1.ConditionTrue)
+}
+
+// Ready or Deny state
+func inFinalState(application *app.M4DApplication) bool {
+	// check if the conditions have been initialized
+	if len(application.Status.Conditions) == 0 {
+		return false
+	}
+	return (application.Status.Conditions[app.ReadyConditionIndex].Status == corev1.ConditionTrue ||
+		application.Status.Conditions[app.DenyConditionIndex].Status == corev1.ConditionTrue)
 }
 
 func getErrorMessages(application *app.M4DApplication) string {
@@ -56,8 +76,8 @@ func getErrorMessages(application *app.M4DApplication) string {
 	if application.Status.Conditions[app.ErrorConditionIndex].Status == corev1.ConditionTrue {
 		errMsg += application.Status.Conditions[app.ErrorConditionIndex].Message
 	}
-	if application.Status.Conditions[app.FailureConditionIndex].Status == corev1.ConditionTrue {
-		errMsg += application.Status.Conditions[app.FailureConditionIndex].Message
+	if application.Status.Conditions[app.DenyConditionIndex].Status == corev1.ConditionTrue {
+		errMsg += application.Status.Conditions[app.DenyConditionIndex].Message
 	}
 	return errMsg
 }

--- a/manager/controllers/app/m4dapplication_controller.go
+++ b/manager/controllers/app/m4dapplication_controller.go
@@ -110,7 +110,7 @@ func (r *M4DApplicationReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	}
 
 	// trigger a new reconcile if required (the m4dapplication is not ready)
-	if !applicationContext.Status.Ready {
+	if !inFinalState(applicationContext) {
 		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 	}
 	return ctrl.Result{}, nil
@@ -122,14 +122,13 @@ func getBucketResourceRef(name string) *types.NamespacedName {
 
 func (r *M4DApplicationReconciler) checkReadiness(applicationContext *app.M4DApplication, status app.ObservedState) error {
 	applicationContext.Status.DataAccessInstructions = ""
-	applicationContext.Status.Ready = false
 	resetConditions(applicationContext)
 	if applicationContext.Status.CatalogedAssets == nil {
 		applicationContext.Status.CatalogedAssets = make(map[string]string)
 	}
 
 	if status.Error != "" {
-		setCondition(applicationContext, "", status.Error, true)
+		setErrorCondition(applicationContext, "", status.Error)
 		return nil
 	}
 	if !status.Ready {
@@ -164,7 +163,7 @@ func (r *M4DApplicationReconciler) checkReadiness(applicationContext *app.M4DApp
 			}
 		}
 	}
-	applicationContext.Status.Ready = true
+	setReadyCondition(applicationContext, "")
 	applicationContext.Status.DataAccessInstructions = status.DataAccessInstructions
 	return nil
 }
@@ -272,7 +271,6 @@ func (r *M4DApplicationReconciler) reconcile(applicationContext *app.M4DApplicat
 	// clear status
 	resetConditions(applicationContext)
 	applicationContext.Status.DataAccessInstructions = ""
-	applicationContext.Status.Ready = false
 	if applicationContext.Status.ProvisionedStorage == nil {
 		applicationContext.Status.ProvisionedStorage = make(map[string]app.DatasetDetails)
 	}
@@ -283,7 +281,7 @@ func (r *M4DApplicationReconciler) reconcile(applicationContext *app.M4DApplicat
 			return ctrl.Result{}, err
 		}
 		r.Log.V(0).Info("no blueprint will be generated since no datasets are specified")
-		applicationContext.Status.Ready = true
+		setReadyCondition(applicationContext, "")
 		return ctrl.Result{}, nil
 	}
 
@@ -298,7 +296,8 @@ func (r *M4DApplicationReconciler) reconcile(applicationContext *app.M4DApplicat
 			Context: dataset.DeepCopy(),
 		}
 		if err := r.constructDataInfo(&req, applicationContext, clusters); err != nil {
-			return ctrl.Result{}, err
+			AnalyzeError(applicationContext, req.Context.DataSetID, err)
+			continue
 		}
 		requirements = append(requirements, req)
 	}
@@ -327,7 +326,7 @@ func (r *M4DApplicationReconciler) reconcile(applicationContext *app.M4DApplicat
 	for _, item := range requirements {
 		instancesPerDataset, err := moduleManager.SelectModuleInstances(item, applicationContext)
 		if err != nil {
-			setCondition(applicationContext, item.Context.DataSetID, err.Error(), true)
+			setErrorCondition(applicationContext, item.Context.DataSetID, err.Error())
 		}
 		instances = append(instances, instancesPerDataset...)
 	}
@@ -382,7 +381,7 @@ func (r *M4DApplicationReconciler) reconcile(applicationContext *app.M4DApplicat
 	if err := r.ResourceInterface.CreateOrUpdateResource(ownerRef, resourceRef, blueprintPerClusterMap); err != nil {
 		r.Log.V(0).Info("Error creating " + resourceRef.Kind + " : " + err.Error())
 		if err.Error() == app.InvalidClusterConfiguration {
-			setCondition(applicationContext, "", app.InvalidClusterConfiguration, true)
+			setErrorCondition(applicationContext, "", app.InvalidClusterConfiguration)
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, err
@@ -471,15 +470,13 @@ func (r *M4DApplicationReconciler) SetupWithManager(mgr ctrl.Manager) error {
 // AnalyzeError analyzes whether the given error is fatal, or a retrial attempt can be made.
 // Reasons for retrial can be either communication problems with external services, or kubernetes problems to perform some action on a resource.
 // A retrial is achieved by returning an error to the reconcile method
-func AnalyzeError(app *app.M4DApplication, log logr.Logger, assetID string, err error) error {
+func AnalyzeError(app *app.M4DApplication, assetID string, err error) {
 	errStatus, _ := status.FromError(err)
-	log.V(0).Info(errStatus.Message())
 	if errStatus.Code() == codes.InvalidArgument {
-		setCondition(app, assetID, errStatus.Message(), true)
-		return nil
+		setDenyCondition(app, assetID, errStatus.Message())
+	} else {
+		setErrorCondition(app, assetID, errStatus.Message())
 	}
-	setCondition(app, assetID, errStatus.Message(), false)
-	return err
 }
 
 func ownerLabels(id types.NamespacedName) map[string]string {

--- a/manager/controllers/app/m4dapplication_controller_unit_test.go
+++ b/manager/controllers/app/m4dapplication_controller_unit_test.go
@@ -208,13 +208,13 @@ func TestDenyOnRead(t *testing.T) {
 
 	res, err := r.Reconcile(context.Background(), req)
 	g.Expect(err).To(gomega.BeNil())
-	g.Expect(res).To(gomega.BeEquivalentTo(ctrl.Result{}))
 
 	err = cl.Get(context.TODO(), req.NamespacedName, application)
 	g.Expect(err).To(gomega.BeNil(), "Cannot fetch m4dapplication")
 	// Expect Deny condition
-	g.Expect(application.Status.Conditions[app.DenyConditionIndex].Status).To(gomega.BeIdenticalTo(corev1.ConditionTrue))
+	g.Expect(application.Status.Conditions[app.DenyConditionIndex].Status).To(gomega.BeIdenticalTo(corev1.ConditionTrue), "Deny condition is not set")
 	g.Expect(getErrorMessages(application)).To(gomega.ContainSubstring(app.ReadAccessDenied))
+	g.Expect(res).To(gomega.BeEquivalentTo(ctrl.Result{}), "Requests another reconcile")
 }
 
 // Tests selection of read-path module

--- a/manager/controllers/motion/suite_test.go
+++ b/manager/controllers/motion/suite_test.go
@@ -129,4 +129,3 @@ var _ = AfterSuite(func() {
 	err := testEnv.Stop()
 	Expect(err).ToNot(HaveOccurred())
 })
-


### PR DESCRIPTION
May fix https://github.com/mesh-for-data/mesh-for-data/issues/708

This PR has the following changes:
- conditions are Ready, Deny, Error instead of Error, Failure (Deny is set either if access is denied, or the asset does not exist)
- error analysis to determine the appropriate condition including grpc errors
- reconcile if app is not in Ready or Deny state instead of reconcile if app is not Ready
- added a check in DenyOnRead test whether a new reconcile will be made