### PR TITLE
Make schema registry for optional for Kafka

### DIFF
--- a/charts/m4d-crd/templates/motion.m4d.ibm.com_batchtransfers.yaml
+++ b/charts/m4d-crd/templates/motion.m4d.ibm.com_batchtransfers.yaml
@@ -212,7 +212,6 @@ spec:
                     required:
                     - kafkaBrokers
                     - kafkaTopic
-                    - schemaRegistryURL
                     type: object
                   s3:
                     description: An object store data store that is compatible with S3. This can be a COS bucket.
@@ -480,7 +479,6 @@ spec:
                     required:
                     - kafkaBrokers
                     - kafkaTopic
-                    - schemaRegistryURL
                     type: object
                   s3:
                     description: An object store data store that is compatible with S3. This can be a COS bucket.

--- a/charts/m4d-crd/templates/motion.m4d.ibm.com_streamtransfers.yaml
+++ b/charts/m4d-crd/templates/motion.m4d.ibm.com_streamtransfers.yaml
@@ -209,7 +209,6 @@ spec:
                     required:
                     - kafkaBrokers
                     - kafkaTopic
-                    - schemaRegistryURL
                     type: object
                   s3:
                     description: An object store data store that is compatible with S3. This can be a COS bucket.
@@ -464,7 +463,6 @@ spec:
                     required:
                     - kafkaBrokers
                     - kafkaTopic
-                    - schemaRegistryURL
                     type: object
                   s3:
                     description: An object store data store that is compatible with S3. This can be a COS bucket.

--- a/manager/apis/motion/v1alpha1/batchtransfer_types.go
+++ b/manager/apis/motion/v1alpha1/batchtransfer_types.go
@@ -244,7 +244,8 @@ type Kafka struct {
 	KafkaBrokers string `json:"kafkaBrokers"`
 
 	// URL to the schema registry. The registry has to be Confluent schema registry compatible.
-	SchemaRegistryURL string `json:"schemaRegistryURL"`
+	// +optional
+	SchemaRegistryURL string `json:"schemaRegistryURL,omitempty"`
 
 	// Kafka security protocol one of (PLAINTEXT, SASL_PLAINTEXT, SASL_SSL, SSL)
 	// Default SASL_SSL will be assumed if not specified

--- a/manager/apis/motion/v1alpha1/batchtransfer_webhook.go
+++ b/manager/apis/motion/v1alpha1/batchtransfer_webhook.go
@@ -243,15 +243,17 @@ func validateDataStore(path *field.Path, store *DataStore) []*field.Error {
 		}
 
 		// Validate Kafka schema registry url
-		schemaRegistryURL, err := url.Parse(store.Kafka.SchemaRegistryURL)
-		if err != nil {
-			allErrs = append(allErrs, field.Invalid(kafkaPath.Child("schemaRegistryUrl"), store.Kafka.SchemaRegistryURL, "Could not parse url!"))
-		}
-		if schemaRegistryURL != nil {
-			errs := validateHostPort(schemaRegistryURL.Host)
-			for _, err := range errs {
-				errMsg := "Invalid host: " + err
-				allErrs = append(allErrs, field.Invalid(kafkaPath.Child("schemaRegistryUrl"), store.Kafka.SchemaRegistryURL, errMsg))
+		if len(store.Kafka.SchemaRegistryURL) != 0 {
+			schemaRegistryURL, err := url.Parse(store.Kafka.SchemaRegistryURL)
+			if err != nil {
+				allErrs = append(allErrs, field.Invalid(kafkaPath.Child("schemaRegistryUrl"), store.Kafka.SchemaRegistryURL, "Could not parse url!"))
+			}
+			if schemaRegistryURL != nil {
+				errs := validateHostPort(schemaRegistryURL.Host)
+				for _, err := range errs {
+					errMsg := "Invalid host: " + err
+					allErrs = append(allErrs, field.Invalid(kafkaPath.Child("schemaRegistryUrl"), store.Kafka.SchemaRegistryURL, errMsg))
+				}
 			}
 		}
 


### PR DESCRIPTION
When e.g. JSON is used as a data format in Kafka there is no need for a schema registry. 